### PR TITLE
Add support for custom code execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM gruntwork/terragrunt:0.0.1
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 COPY ["./src/main.sh", "/action/main.sh"]
-# COPY /home/runner/.gitconfi[g] /root/
+
 ENTRYPOINT ["/action/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,4 @@ FROM gruntwork/terragrunt:0.0.1
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 COPY ["./src/main.sh", "/action/main.sh"]
-
 ENTRYPOINT ["/action/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM gruntwork/terragrunt:0.0.1
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 COPY ["./src/main.sh", "/action/main.sh"]
-COPY /home/runner/.gitconfi[g] /root/
+# COPY /home/runner/.gitconfi[g] /root/
 ENTRYPOINT ["/action/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ FROM gruntwork/terragrunt:0.0.1
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 COPY ["./src/main.sh", "/action/main.sh"]
-COPY ["/home/runner/.gitconfi[g]", "/root/"]
+COPY /home/runner/.gitconfi[g] /root/
 ENTRYPOINT ["/action/main.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,5 @@ FROM gruntwork/terragrunt:0.0.1
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 COPY ["./src/main.sh", "/action/main.sh"]
+COPY ["/home/runner/.gitconfi[g]", "/root/"]
 ENTRYPOINT ["/action/main.sh"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # terragrunt-action
+
 A GitHub Action for installing and running Terragrunt
 
 ## Inputs
@@ -13,6 +14,12 @@ Supported GitHub action inputs:
 | tg_command | Terragrunt command to execute                     |  `true`  |
 | tg_comment | Add comment to Pull request with execution output | `false`  |
 
+Environment variables:
+
+| Name                    | Description                                                                                                 | 
+|:------------------------|:------------------------------------------------------------------------------------------------------------|
+| INPUT_PRE_EXEC_<number> | environment variable is utilized to provide custom commands that will be executed before running Terragrunt |
+
 ## Outputs
 
 Outputs of GitHub action:
@@ -25,6 +32,7 @@ Outputs of GitHub action:
 ## Environment Variables
 
 Supported environment variables:
+
 * `GITHUB_TOKEN` - GitHub token used to add comment to Pull request
 * `TF_LOG` - log level for Terraform
 * `TF_VAR_name` - Define custom variable name as inputs
@@ -32,6 +40,7 @@ Supported environment variables:
 ## Usage
 
 Example definition of Github Action workflow:
+
 ```yaml
 name: 'Terragrunt GitHub Actions'
 on:
@@ -59,7 +68,7 @@ jobs:
 
   plan:
     runs-on: ubuntu-latest
-    needs: [checks]
+    needs: [ checks ]
     steps:
       - name: 'Checkout'
         uses: actions/checkout@master
@@ -74,7 +83,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [plan]
+    needs: [ plan ]
     environment: 'prod'
     if: github.ref == 'refs/heads/master'
     steps:
@@ -90,3 +99,20 @@ jobs:
           tg_command: 'apply'
 ```
 
+Example of passing custom code before running Terragrunt:
+
+```yaml
+...
+- name: Plan
+  uses: gruntwork-io/terragrunt-action@v1
+  env:
+    # configure git to use custom token to clone repository.
+    INPUT_PRE_EXEC_0: |
+      git config --global url."https://user:${{secrets.PAT_TOKEN}}@github.com".insteadOf "https://github.com"
+  with:
+    tf_version: ${{ env.tf_version }}
+    tg_version: ${{ env.tg_version }}
+    tg_dir: ${{ env.working_dir }}
+    tg_command: 'run-all plan'
+...
+```

--- a/README.md
+++ b/README.md
@@ -14,11 +14,16 @@ Supported GitHub action inputs:
 | tg_command | Terragrunt command to execute                     |  `true`  |
 | tg_comment | Add comment to Pull request with execution output | `false`  |
 
-Environment variables:
+## Environment Variables
 
-| Name                    | Description                                                                                                 | 
-|:------------------------|:------------------------------------------------------------------------------------------------------------|
-| INPUT_PRE_EXEC_<number> | environment variable is utilized to provide custom commands that will be executed before running Terragrunt |
+Supported environment variables:
+
+| Input Name            | Description                                                                                                 | 
+|:----------------------|:------------------------------------------------------------------------------------------------------------|
+| GITHUB_TOKEN          | GitHub token used to add comment to Pull request                                                            |
+| TF_LOG                | Log level for Terraform                                                                                     |
+| TF_VAR_name           | Define custom variable name as inputs                                                                       |
+| INPUT_PRE_EXEC_number | Environment variable is utilized to provide custom commands that will be executed before running Terragrunt |
 
 ## Outputs
 
@@ -27,15 +32,7 @@ Outputs of GitHub action:
 | Input Name          | Description                     |
 |:--------------------|:--------------------------------|
 | tg_action_exit_code | Terragrunt exit code            |
-| tg_action_output    | Terragrunt output as plain text | 
-
-## Environment Variables
-
-Supported environment variables:
-
-* `GITHUB_TOKEN` - GitHub token used to add comment to Pull request
-* `TF_LOG` - log level for Terraform
-* `TF_VAR_name` - Define custom variable name as inputs
+| tg_action_output    | Terragrunt output as plain text |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ Example of passing custom code before running Terragrunt:
   uses: gruntwork-io/terragrunt-action@v1
   env:
     # configure git to use custom token to clone repository.
-    INPUT_PRE_EXEC_0: |
+    INPUT_PRE_EXEC_1: |
       git config --global url."https://user:${{secrets.PAT_TOKEN}}@github.com".insteadOf "https://github.com"
+    # print git configuration
+    INPUT_PRE_EXEC_2: |
+      git config --global --list
   with:
-    tf_version: ${{ env.tf_version }}
-    tg_version: ${{ env.tg_version }}
-    tg_dir: ${{ env.working_dir }}
-    tg_command: 'run-all plan'
+    tg_command: 'plan'
 ...
 ```

--- a/src/main.sh
+++ b/src/main.sh
@@ -123,7 +123,7 @@ function main {
   fi
   setup_git
 
-  log "git config 1"
+  log "git config 2"
   git config --list
 
   install_terraform "${tf_version}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -82,6 +82,15 @@ function setup_git {
 
 function main {
 
+  log "/github/home"
+  ls -lahrt /github/home
+
+  log "/github/workflow"
+  ls -lahrt /github/workflow
+
+  log "/github/file_command"
+  ls -lahrt /github/file_command
+
   pwd
   ls -lahrt .
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -80,12 +80,17 @@ function setup_git {
   git config --global --add safe.directory /github/workspace
 }
 
+# Run PRE_EXEC_* environment variables as Bash code
+function setup_pre_exec {
+    # Get all environment variables that match the pattern PRE_EXEC_*
+    local -r pre_exec_vars=$(env | grep -o '^PRE_EXEC_[0-9]\+=' | sort)
+    # Loop through each pre-execution variable and execute its value (Bash code)
+    while IFS= read -r pre_exec_var; do
+        eval "${!pre_exec_var}"
+    done <<< "$pre_exec_vars"
+}
+
 function main {
-
-  log "git config 1"
-  git config --list
-
-
   log "Starting Terragrunt Action"
   trap 'log "Finished Terragrunt Action execution"' EXIT
   local -r tf_version=${INPUT_TF_VERSION}
@@ -109,9 +114,7 @@ function main {
     exit 1
   fi
   setup_git
-
-  log "git config 2"
-  git config --list
+  setup_pre_exec
 
   install_terraform "${tf_version}"
   install_terragrunt "${tg_version}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -84,7 +84,7 @@ function setup_git {
 function setup_pre_exec {
   env
   # Get all environment variables that match the pattern INPUT_PRE_EXEC_*
-  local -r pre_exec_vars=$(env | grep -o '^INPUT_PRE_EXEC_[0-9]\+=' | sort)
+  local -r pre_exec_vars=$(env | grep -o '^INPUT_PRE_EXEC_[0-9]\+' | sort)
   # Loop through each pre-execution variable and execute its value (Bash code)
   while IFS= read -r pre_exec_var; do
     log "Evaluating ${pre_exec_var}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -87,6 +87,7 @@ function setup_pre_exec {
   local -r pre_exec_vars=$(env | grep -o '^INPUT_PRE_EXEC_[0-9]\+=' | sort)
   # Loop through each pre-execution variable and execute its value (Bash code)
   while IFS= read -r pre_exec_var; do
+    log "Evaluating ${pre_exec_var}"
     local -r pre_exec_command="${!pre_exec_var}"
     if [ -n "$pre_exec_command" ]; then
         eval "$pre_exec_command"

--- a/src/main.sh
+++ b/src/main.sh
@@ -82,12 +82,13 @@ function setup_git {
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code
 function setup_pre_exec {
-    # Get all environment variables that match the pattern INPUT_PRE_EXEC_*
-    local -r pre_exec_vars=$(env | grep -o '^INPUT_PRE_EXEC_[0-9]\+=' | sort)
-    # Loop through each pre-execution variable and execute its value (Bash code)
-    while IFS= read -r pre_exec_var; do
-        eval "${!pre_exec_var}"
-    done <<< "$pre_exec_vars"
+  env
+  # Get all environment variables that match the pattern INPUT_PRE_EXEC_*
+  local -r pre_exec_vars=$(env | grep -o '^INPUT_PRE_EXEC_[0-9]\+=' | sort)
+  # Loop through each pre-execution variable and execute its value (Bash code)
+  while IFS= read -r pre_exec_var; do
+      eval "${!pre_exec_var}"
+  done <<< "$pre_exec_vars"
 }
 
 function main {

--- a/src/main.sh
+++ b/src/main.sh
@@ -81,6 +81,10 @@ function setup_git {
 }
 
 function main {
+
+  pwd
+  ls -lahrt .
+
   log "Starting Terragrunt Action"
   trap 'log "Finished Terragrunt Action execution"' EXIT
   local -r tf_version=${INPUT_TF_VERSION}

--- a/src/main.sh
+++ b/src/main.sh
@@ -82,6 +82,8 @@ function setup_git {
 
 function main {
 
+  env
+
   log "/github/home"
   ls -lahrt /github/home
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -88,8 +88,8 @@ function main {
   log "/github/workflow"
   ls -lahrt /github/workflow
 
-  log "/github/file_command"
-  ls -lahrt /github/file_command
+  log "/github/file_commands"
+  ls -lahrt /github/file_commands
 
   pwd
   ls -lahrt .

--- a/src/main.sh
+++ b/src/main.sh
@@ -80,10 +80,10 @@ function setup_git {
   git config --global --add safe.directory /github/workspace
 }
 
-# Run PRE_EXEC_* environment variables as Bash code
+# Run INPUT_PRE_EXEC_* environment variables as Bash code
 function setup_pre_exec {
-    # Get all environment variables that match the pattern PRE_EXEC_*
-    local -r pre_exec_vars=$(env | grep -o '^PRE_EXEC_[0-9]\+=' | sort)
+    # Get all environment variables that match the pattern INPUT_PRE_EXEC_*
+    local -r pre_exec_vars=$(env | grep -o '^INPUT_PRE_EXEC_[0-9]\+=' | sort)
     # Loop through each pre-execution variable and execute its value (Bash code)
     while IFS= read -r pre_exec_var; do
         eval "${!pre_exec_var}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -82,22 +82,9 @@ function setup_git {
 
 function main {
 
-  env
-
-  log "/github/home"
-  ls -lahrt /github/home
-
-  log "/github/workflow"
-  ls -lahrt /github/workflow
-
-  log "/github/file_commands"
-  ls -lahrt /github/file_commands
-
   log "git config 1"
   git config --list
 
-  pwd
-  ls -lahrt .
 
   log "Starting Terragrunt Action"
   trap 'log "Finished Terragrunt Action execution"' EXIT

--- a/src/main.sh
+++ b/src/main.sh
@@ -93,6 +93,9 @@ function main {
   log "/github/file_commands"
   ls -lahrt /github/file_commands
 
+  log "git config 1"
+  git config --list
+
   pwd
   ls -lahrt .
 
@@ -119,6 +122,10 @@ function main {
     exit 1
   fi
   setup_git
+
+  log "git config 1"
+  git config --list
+
   install_terraform "${tf_version}"
   install_terragrunt "${tg_version}"
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -86,9 +86,10 @@ function setup_pre_exec {
   # Get all environment variables that match the pattern INPUT_PRE_EXEC_*
   local -r pre_exec_vars=$(env | grep -o '^INPUT_PRE_EXEC_[0-9]\+' | sort)
   # Loop through each pre-execution variable and execute its value (Bash code)
+  local pre_exec_command
   while IFS= read -r pre_exec_var; do
     log "Evaluating ${pre_exec_var}"
-    local -r pre_exec_command="${!pre_exec_var}"
+    pre_exec_command="${!pre_exec_var}"
     if [ -n "$pre_exec_command" ]; then
         eval "$pre_exec_command"
     fi

--- a/src/main.sh
+++ b/src/main.sh
@@ -87,7 +87,10 @@ function setup_pre_exec {
   local -r pre_exec_vars=$(env | grep -o '^INPUT_PRE_EXEC_[0-9]\+=' | sort)
   # Loop through each pre-execution variable and execute its value (Bash code)
   while IFS= read -r pre_exec_var; do
-      eval "${!pre_exec_var}"
+    local -r pre_exec_command="${!pre_exec_var}"
+    if [ -n "$pre_exec_command" ]; then
+        eval "$pre_exec_command"
+    fi
   done <<< "$pre_exec_vars"
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Added support for passing environment variables with custom commands which will be executed before running Terragrunt - helpful to do environment configurations since Terragrunt is executed in separated container which doesn't inherit settings from previous steps.

For example, can passed commands to set global git settings: `git config --global `

Included changes:
 * added identification of INPUT_PRE_EXEC_number variables and execution of code
 * update documentation to reference usage

Fixes #5

<!-- Description of the changes introduced by this PR. -->

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added support for env variables `INPUT_PRE_EXEC_<number>` which can be used to pass custom bash commands to be executed before running Terragrunt.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

