### PR TITLE
Fall back to issue comment url

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -66,6 +66,10 @@ function comment {
   local -r message="$1"
   local comment_url
   comment_url=$(jq -r '.pull_request.comments_url' "$GITHUB_EVENT_PATH")
+  # may be getting called from something like branch deploy
+  if [[ "${comment_url}" == "" || "${comment_url}" == "null" ]]; then
+    comment_url=$(jq -r '.issue.comments_url' "$GITHUB_EVENT_PATH")
+  fi
   if [[ "${comment_url}" == "" || "${comment_url}" == "null" ]]; then
     log "Skipping comment as there is not comment url"
     return


### PR DESCRIPTION
When using a comment-base workflow like with [Branch Deploy Action](https://github.com/marketplace/actions/branch-deploy), the `comment_url` field is on `issue` instead of `pull_request`. This change checks for `.issue.comments_url` if `.pull_request.comments_url` is empty.