### PR TITLE
Fix folder permissions issue

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -82,6 +82,8 @@ function comment {
 function setup_git {
   # Avoid git permissions warnings
   git config --global --add safe.directory /github/workspace
+  # Also trust any subfolder within workspace
+  git config --global --add safe.directory /github/workspace/*
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code


### PR DESCRIPTION
This fix addresses an issue where terragrunt throws an issue when calling functions like `get_repo_root` which uses `git rev-parse` under the hood and gets a permissions error like:

```
git rev-parse --show-toplevel
fatal: detected dubious ownership in repository at '/github/workspace/infrastructure-live'
To add an exception for this directory, call:

        git config --global --add safe.directory /github/workspace/infrastructure-live
```