### PR TITLE
Encode heredoc for terragrunt action output

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -21,6 +21,7 @@ function clean_multiline_text {
   output="${input//'%'/'%25'}"
   output="${output//$'\n'/'%0A'}"
   output="${output//$'\r'/'%0D'}"
+  output="${output//$'<'/'%3C'}"
   echo "${output}"
 }
 


### PR DESCRIPTION
Fixes heredoc encoding issue in Github Action:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'tg_action_output=%0AInitializing the backend...%0A%0ASuccessfully configured the backend "s3"! Terraform will automatically%0Ause this backend unless the backend configuration changes.%0AInitializing modules..
```