### PR TITLE
Fixed setting of safe directories

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -85,7 +85,7 @@ function setup_git {
   # Avoid git permissions warnings
   git config --global --add safe.directory /github/workspace
   # Also trust any subfolder within workspace
-  git config --global --add safe.directory /github/workspace/*
+  # git config --global --add safe.directory "*"
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -85,7 +85,7 @@ function setup_git {
   # Avoid git permissions warnings
   git config --global --add safe.directory /github/workspace
   # Also trust any subfolder within workspace
-  #git config --global --add safe.directory "*"
+  git config --global --add safe.directory "*"
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -85,7 +85,7 @@ function setup_git {
   # Avoid git permissions warnings
   git config --global --add safe.directory /github/workspace
   # Also trust any subfolder within workspace
-  # git config --global --add safe.directory "*"
+  git config --global --add safe.directory "*"
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -x
 
 # write log message with timestamp
 function log {

--- a/src/main.sh
+++ b/src/main.sh
@@ -84,7 +84,7 @@ function setup_git {
   # Avoid git permissions warnings
   git config --global --add safe.directory /github/workspace
   # Also trust any subfolder within workspace
-  git config --global --add safe.directory "*"
+  git config --global --add safe.directory "/github/workspace/*"
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -84,7 +84,7 @@ function setup_git {
   # Avoid git permissions warnings
   git config --global --add safe.directory /github/workspace
   # Also trust any subfolder within workspace
-  git config --global --add safe.directory "/github/workspace/*"
+  git config --global --add safe.directory "*"
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -85,7 +85,7 @@ function setup_git {
   # Avoid git permissions warnings
   git config --global --add safe.directory /github/workspace
   # Also trust any subfolder within workspace
-  git config --global --add safe.directory "*"
+  #git config --global --add safe.directory "*"
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -e
-set -x
 
 # write log message with timestamp
 function log {


### PR DESCRIPTION
Included changes:
 - fixed setting of git safe.directory to not include local directories

Before this change:

```
error: wrong number of arguments, should be 2
usage: git config [<options>]

Config file location
    --global              use global config file
    --system              use system config file
```

After this change:
```
Initializing the backend...

Initializing provider plugins...

Terraform has been successfully initialized!
```

Closes: #15