### PR TITLE
Update action name and description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,11 @@
-name: 'Terragrunt Github Action'
-description: 'Guithub Action for Terragrunt.'
-author:  'info@gruntwork.io'
+name: 'Gruntwork Terragrunt'
+description: 'Setup and execute Terragrunt.'
+author:  'Gruntwork'
+
 branding:
   icon: 'award'
-  color: 'green'
+  color: 'purple'
+
 inputs:
   tg_version:
     description: 'Terragrunt version to install.'


### PR DESCRIPTION
- There was a typo in the description.
- Updating to match https://github.com/gruntwork-io/patcher-action/blob/main/action.yml.

This shouldn't affect users, given they use the repo name to refer to the action.