### PR TITLE
Collapsive output message

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -155,7 +155,7 @@ function main {
     comment "<details>
 <summary>Execution result of \`$tg_command\` in \`${tg_dir}\`</summary>
 
-\`\`\`
+\`\`\`terraform
 ${terragrunt_output}
 \`\`\`
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -152,10 +152,14 @@ function main {
   terragrunt_output=$(clean_colors "${terragrunt_log_content}")
 
   if [[ "${tg_comment}" == "1" ]]; then
-    comment "Execution result of \`$tg_command\` in \`${tg_dir}\` :
+    comment "<details>
+<summary>Execution result of \`$tg_command\` in \`${tg_dir}\`</summary>
+
 \`\`\`
 ${terragrunt_output}
 \`\`\`
+
+</details>
     "
   fi
 


### PR DESCRIPTION
Add command output in a `<details>` block to avoid huge comments, specially in `run-all` commands