### PR TITLE
docs(usage): update action/checkout default branch from master

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Check terragrunt HCL
         uses: gruntwork-io/terragrunt-action@v1
@@ -68,7 +68,7 @@ jobs:
     needs: [ checks ]
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Plan
         uses: gruntwork-io/terragrunt-action@v1
@@ -82,10 +82,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ plan ]
     environment: 'prod'
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Deploy
         uses: gruntwork-io/terragrunt-action@v1


### PR DESCRIPTION
the `actions/checkout@master` is out of date since the default branch is now main, since the [announcement](https://github.com/github/renaming#renaming-the-default-branch-from-master). updated the usage example to reference main (latest) so the action is not out of date.