### PR TITLE
Action workspace permissions fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A GitHub Action for installing and running Terragrunt
 
 Supported GitHub action inputs:
 
-| Input Name | Description                                       | Required | Example values |
-|:-----------|:--------------------------------------------------|:--------:|:--------------:|
-| tf_version | Terraform version to be used in Action execution  |  `true`  |     1.4.6      | 
-| tg_version | Terragrunt version to be user in Action execution |  `true`  |     0.50.8     |
-| tg_dir     | Directory in which Terragrunt will be invoked     |  `true`  |      work      |
-| tg_command | Terragrunt command to execute                     |  `true`  |   plan/apply   |
-| tg_comment | Add comment to Pull request with execution output | `false`  |      0/1       |
+| Input Name     | Description                                                       | Required | Example values |
+|:---------------|:------------------------------------------------------------------|:--------:|:--------------:|
+| tf_version     | Terraform version to be used in Action execution                  |  `true`  |     1.4.6      | 
+| tg_version     | Terragrunt version to be user in Action execution                 |  `true`  |     0.50.8     |
+| tg_dir         | Directory in which Terragrunt will be invoked                     |  `true`  |      work      |
+| tg_command     | Terragrunt command to execute                                     |  `true`  |   plan/apply   |
+| tg_comment     | Add comment to Pull request with execution output                 | `false`  |      0/1       |
+| tg_add_approve | Automatically add "-auto-approve" to commands, enabled by default | `false`  |      0/1       |
 
 ## Environment Variables
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Include execution output as comment'
     default: '0'
     required: false
+  tg_add_approve:
+    description: 'Add -auto-approve to commands which require changes to be applied'
+    default: '1'
+    required: false
 outputs:
   tg_action_output:
     description: 'Terragrunt execution output'

--- a/src/main.sh
+++ b/src/main.sh
@@ -88,6 +88,11 @@ function setup_git {
   sudo git config --global --add safe.directory "*"
 }
 
+function setup_permissions {
+  # Set permissions for the output file
+  sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
+}
+
 # Run INPUT_PRE_EXEC_* environment variables as Bash code
 function setup_pre_exec {
   # Get all environment variables that match the pattern INPUT_PRE_EXEC_*

--- a/src/main.sh
+++ b/src/main.sh
@@ -89,9 +89,10 @@ function setup_git {
 }
 
 function setup_permissions {
+  local -r dir="${1}"
   # Set permissions for current user
-  sudo chown -R $(whoami) .
-  sudo chmod -R o+rw .
+  sudo chown -R $(whoami) "${dir}"
+  sudo chmod -R o+rw "${dir}"
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }
@@ -151,8 +152,8 @@ function main {
     exit 1
   fi
   setup_git
-  setup_permissions
-  trap setup_permissions EXIT
+  setup_permissions "${tg_dir}"
+  trap 'setup_permissions $tg_dir ' EXIT
   setup_pre_exec
 
   install_terraform "${tf_version}"
@@ -176,7 +177,7 @@ function main {
     fi
   fi
   run_terragrunt "${tg_dir}" "${tg_arg_and_commands}"
-  setup_permissions
+  setup_permissions "${tg_dir}"
   # setup permissions for the output files
   setup_post_exec
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -92,6 +92,7 @@ function setup_permissions {
   local working_dir=$1
   # Set permissions for current user
   sudo chown -R $(whoami) "${working_dir}"
+  sudo chmod -R o+r "${working_dir}"
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }
@@ -163,7 +164,8 @@ function main {
     export TF_IN_AUTOMATION=1
   fi
   run_terragrunt "${tg_dir}" "${tg_command}"
-
+  # setup permissions for the output files
+  setup_permissions "${tg_dir}"
   setup_post_exec
 
   local -r log_file="${terragrunt_log_file}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -151,6 +151,7 @@ function main {
   fi
   setup_git
   setup_permissions
+  trap setup_permissions EXIT
   setup_pre_exec
 
   install_terraform "${tf_version}"
@@ -164,7 +165,6 @@ function main {
   fi
   run_terragrunt "${tg_dir}" "${tg_command}"
   # setup permissions for the output files
-  setup_permissions
   setup_post_exec
 
   local -r log_file="${terragrunt_log_file}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -147,6 +147,7 @@ function main {
     exit 1
   fi
   setup_git
+  setup_permissions
   setup_pre_exec
 
   install_terraform "${tf_version}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -100,8 +100,6 @@ function setup_permissions {
   if [[ -f "${GITHUB_OUTPUT}" ]]; then
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
-  # set permissions for .terraform directories, if any
-  sudo find . -name ".terraform" -exec chmod -R 777 {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -99,6 +99,8 @@ function setup_permissions {
   if [[ -f "${GITHUB_OUTPUT}" ]]; then
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
+  # set permissions for .terraform directories, if any
+  find . -name ".terraform*" -exec chmod sudo chown -R $(whoami) {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -133,6 +133,7 @@ function main {
   local -r tg_version=${INPUT_TG_VERSION}
   local -r tg_command=${INPUT_TG_COMMAND}
   local -r tg_comment=${INPUT_TG_COMMENT:-0}
+  local -r tg_add_approve=${INPUT_TG_ADD_APPROVE:-1}
   local -r tg_dir=${INPUT_TG_DIR:-.}
 
   if [[ -z "${tf_version}" ]]; then
@@ -164,11 +165,13 @@ function main {
     export TF_INPUT=false
     export TF_IN_AUTOMATION=1
 
-    local approvePattern="^(apply|destroy|run-all apply|run-all destroy)"
-    if [[ $tg_arg_and_commands =~ $approvePattern ]]; then
-        local matchedCommand="${BASH_REMATCH[0]}"
-        local remainingArgs="${tg_arg_and_commands#$matchedCommand}"
-        tg_arg_and_commands="${matchedCommand} -auto-approve ${remainingArgs}"
+    if [[ "${tg_add_approve}" == "1" ]]; then
+      local approvePattern="^(apply|destroy|run-all apply|run-all destroy)"
+      if [[ $tg_arg_and_commands =~ $approvePattern ]]; then
+          local matchedCommand="${BASH_REMATCH[0]}"
+          local remainingArgs="${tg_arg_and_commands#$matchedCommand}"
+          tg_arg_and_commands="${matchedCommand} -auto-approve ${remainingArgs}"
+      fi
     fi
   fi
   run_terragrunt "${tg_dir}" "${tg_arg_and_commands}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -91,7 +91,7 @@ function setup_git {
 function setup_permissions {
   # Set permissions for current user
   sudo chown -R $(whoami) .
-  sudo chmod -R o+rw .
+  sudo chmod -R o+rwx .
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -100,7 +100,7 @@ function setup_permissions {
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
   # set permissions for .terraform directories, if any
-  find . -name ".terraform" -exec sudo chown -R 777 {} \;
+  find . -name ".terraform*" -exec sudo chmod -R 777 {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -89,6 +89,9 @@ function setup_git {
 }
 
 function setup_permissions {
+  local working_dir=$1
+  # Set permissions for current user
+  sudo chown -R $(whoami) "${working_dir}"
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }
@@ -147,7 +150,7 @@ function main {
     exit 1
   fi
   setup_git
-  setup_permissions
+  setup_permissions "${tg_dir}"
   setup_pre_exec
 
   install_terraform "${tf_version}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -89,9 +89,11 @@ function setup_git {
 }
 
 function setup_permissions {
+  local dir=$1
   # Set permissions for current user
-  sudo chown -R $(whoami) .
-  sudo chmod -R o+rwx .
+  sudo chown -R $(whoami) "${dir}"
+  ls -lahrt "${dir}"
+  sudo chmod -R 777 "${dir}"
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }
@@ -150,8 +152,8 @@ function main {
     exit 1
   fi
   setup_git
-  setup_permissions
-  trap setup_permissions EXIT
+  setup_permissions "${tg_dir}"
+  trap setup_permissions "${tg_dir}" EXIT
   setup_pre_exec
 
   install_terraform "${tf_version}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -166,6 +166,7 @@ function main {
     export TF_IN_AUTOMATION=1
   fi
   run_terragrunt "${tg_dir}" "${tg_command}"
+  setup_permissions
   # setup permissions for the output files
   setup_post_exec
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -100,7 +100,7 @@ function setup_permissions {
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
   # set permissions for .terraform directories, if any
-  find . -name ".terraform*" -exec chmod sudo chown -R 777 {} \;
+  find . -name ".terraform" -exec sudo chown -R 777 {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -100,7 +100,7 @@ function setup_permissions {
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
   # set permissions for .terraform directories, if any
-  find . -name ".terraform*" -exec sudo chmod -R 777 {} \;
+  find . -name ".terraform" -exec sudo chmod -R 777 {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -91,7 +91,7 @@ function setup_git {
 function setup_permissions {
   # Set permissions for current user
   sudo chown -R $(whoami) .
-  sudo chmod -R o+r .
+  sudo chmod -R o+rw .
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -89,11 +89,10 @@ function setup_git {
 }
 
 function setup_permissions {
-  local dir=$1
   # Set permissions for current user
-  sudo chown -R $(whoami) "${dir}"
-  ls -lahrt "${dir}"
-  sudo chmod -R 777 "${dir}"
+  sudo chown -R $(whoami) .
+  pwd
+  sudo chmod -R 777 .
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }
@@ -152,8 +151,8 @@ function main {
     exit 1
   fi
   setup_git
-  setup_permissions "${tg_dir}"
-  trap setup_permissions "${tg_dir}" EXIT
+  setup_permissions
+  trap setup_permissions EXIT
   setup_pre_exec
 
   install_terraform "${tf_version}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -100,7 +100,7 @@ function setup_permissions {
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
   # set permissions for .terraform directories, if any
-  find . -name ".terraform*" -exec chmod sudo chown -R $(whoami) {} \;
+  find . -name ".terraform*" -exec chmod sudo chown -R 777 {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -83,9 +83,9 @@ function comment {
 
 function setup_git {
   # Avoid git permissions warnings
-  git config --global --add safe.directory /github/workspace
+  sudo git config --global --add safe.directory /github/workspace
   # Also trust any subfolder within workspace
-  git config --global --add safe.directory "*"
+  sudo git config --global --add safe.directory "*"
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -90,6 +90,7 @@ function setup_git {
 
 function setup_permissions {
   # Set permissions for current user
+  echo "Setting permissions for $(whoami) in $(pwd)"
   sudo chown -R $(whoami) .
   pwd
   sudo chmod -R 777 .

--- a/src/main.sh
+++ b/src/main.sh
@@ -167,6 +167,7 @@ function main {
 
     if [[ "${tg_add_approve}" == "1" ]]; then
       local approvePattern="^(apply|destroy|run-all apply|run-all destroy)"
+      # split command and arguments to insert -auto-approve
       if [[ $tg_arg_and_commands =~ $approvePattern ]]; then
           local matchedCommand="${BASH_REMATCH[0]}"
           local remainingArgs="${tg_arg_and_commands#$matchedCommand}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -171,7 +171,7 @@ function main {
       tg_arg_and_commands="${tg_arg_and_commands} -auto-approve"
     fi
   fi
-  run_terragrunt "${tg_dir}" "${tg_command}"
+  run_terragrunt "${tg_dir}" "${tg_arg_and_commands}"
   setup_permissions
   # setup permissions for the output files
   setup_post_exec

--- a/src/main.sh
+++ b/src/main.sh
@@ -33,7 +33,7 @@ function install_terraform {
     return
   fi
   tfenv install "${version}"
-  sudo tfenv use "${version}"
+  tfenv use "${version}"
 }
 
 # install passed terragrunt version

--- a/src/main.sh
+++ b/src/main.sh
@@ -100,6 +100,8 @@ function setup_permissions {
   if [[ -f "${GITHUB_OUTPUT}" ]]; then
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
+  # set permissions for .terraform directories, if any
+  sudo find . -name ".terraform*" -exec chmod -R 777 {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -101,7 +101,7 @@ function setup_permissions {
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
   # set permissions for .terraform directories, if any
-  sudo find . -name ".terraform*" -exec chmod -R 777 {} \;
+  sudo find /github/workspace -name ".terraform*" -exec chmod -R 777 {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -90,6 +90,7 @@ function setup_git {
 
 function setup_permissions {
   local -r dir="${1}"
+  sudo chown -R $(whoami) /github/workspace
   # Set permissions for the working directory
   if [[ -f "${dir}" ]]; then
     sudo chown -R $(whoami) "${dir}"
@@ -100,7 +101,7 @@ function setup_permissions {
     sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
   fi
   # set permissions for .terraform directories, if any
-  find . -name ".terraform" -exec sudo chmod -R 777 {} \;
+  sudo find . -name ".terraform" -exec chmod -R 777 {} \;
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code

--- a/src/main.sh
+++ b/src/main.sh
@@ -33,7 +33,7 @@ function install_terraform {
     return
   fi
   tfenv install "${version}"
-  tfenv use "${version}"
+  sudo tfenv use "${version}"
 }
 
 # install passed terragrunt version
@@ -89,10 +89,9 @@ function setup_git {
 }
 
 function setup_permissions {
-  local working_dir=$1
   # Set permissions for current user
-  sudo chown -R $(whoami) "${working_dir}"
-  sudo chmod -R o+r "${working_dir}"
+  sudo chown -R $(whoami) .
+  sudo chmod -R o+r .
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }
@@ -151,7 +150,7 @@ function main {
     exit 1
   fi
   setup_git
-  setup_permissions "${tg_dir}"
+  setup_permissions
   setup_pre_exec
 
   install_terraform "${tf_version}"
@@ -165,7 +164,7 @@ function main {
   fi
   run_terragrunt "${tg_dir}" "${tg_command}"
   # setup permissions for the output files
-  setup_permissions "${tg_dir}"
+  setup_permissions
   setup_post_exec
 
   local -r log_file="${terragrunt_log_file}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -90,10 +90,8 @@ function setup_git {
 
 function setup_permissions {
   # Set permissions for current user
-  echo "Setting permissions for $(whoami) in $(pwd)"
   sudo chown -R $(whoami) .
-  pwd
-  sudo chmod -R 777 .
+  sudo chmod -R o+rw .
   # Set permissions for the output file
   sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
 }
@@ -160,10 +158,18 @@ function main {
   install_terragrunt "${tg_version}"
 
   # add auto approve for apply and destroy commands
+  local tg_arg_and_commands="${tg_command}"
   if [[ "$tg_command" == "apply"* || "$tg_command" == "destroy"* || "$tg_command" == "run-all apply"* || "$tg_command" == "run-all destroy"* ]]; then
     export TERRAGRUNT_NON_INTERACTIVE=true
     export TF_INPUT=false
     export TF_IN_AUTOMATION=1
+    if [[ $tg_arg_and_commands == *" "* ]]; then
+      local -r prefix="${tg_arg_and_commands%% *}"
+      local -r suffix="${tg_arg_and_commands#* }"
+      tg_arg_and_commands="${prefix} -auto-approve ${suffix}"
+    else
+      tg_arg_and_commands="${tg_arg_and_commands} -auto-approve"
+    fi
   fi
   run_terragrunt "${tg_dir}" "${tg_command}"
   setup_permissions

--- a/src/main.sh
+++ b/src/main.sh
@@ -163,12 +163,12 @@ function main {
     export TERRAGRUNT_NON_INTERACTIVE=true
     export TF_INPUT=false
     export TF_IN_AUTOMATION=1
-    if [[ $tg_arg_and_commands == *" "* ]]; then
-      local -r prefix="${tg_arg_and_commands%% *}"
-      local -r suffix="${tg_arg_and_commands#* }"
-      tg_arg_and_commands="${prefix} -auto-approve ${suffix}"
-    else
-      tg_arg_and_commands="${tg_arg_and_commands} -auto-approve"
+
+    local approvePattern="^(apply|destroy|run-all apply|run-all destroy)"
+    if [[ $tg_arg_and_commands =~ $approvePattern ]]; then
+        local matchedCommand="${BASH_REMATCH[0]}"
+        local remainingArgs="${tg_arg_and_commands#$matchedCommand}"
+        tg_arg_and_commands="${matchedCommand} -auto-approve ${remainingArgs}"
     fi
   fi
   run_terragrunt "${tg_dir}" "${tg_arg_and_commands}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -90,11 +90,15 @@ function setup_git {
 
 function setup_permissions {
   local -r dir="${1}"
-  # Set permissions for current user
-  sudo chown -R $(whoami) "${dir}"
-  sudo chmod -R o+rw "${dir}"
+  # Set permissions for the working directory
+  if [[ -f "${dir}" ]]; then
+    sudo chown -R $(whoami) "${dir}"
+    sudo chmod -R o+rw "${dir}"
+  fi
   # Set permissions for the output file
-  sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
+  if [[ -f "${GITHUB_OUTPUT}" ]]; then
+    sudo chown -R $(whoami) "${GITHUB_OUTPUT}"
+  fi
 }
 
 # Run INPUT_PRE_EXEC_* environment variables as Bash code


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Included changes:
* added step to configure action workspace permissions
* added injection of `-auto-approve` for actions that require approval(with option to disable adding through input `tg_add_approve`)

Fixes #47.
Fixes #39.

<!-- Description of the changes introduced by this PR. -->

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated permissions settings to avoid errors like `/github/home/.gitconfig: Permission denied`

Added automatic adding of `-auto-approve` in cases when it is required.

### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

