### PR TITLE
Add tg_output variable for JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Outputs of GitHub action:
 |:--------------------|:--------------------------------|
 | tg_action_exit_code | Terragrunt exit code            |
 | tg_action_output    | Terragrunt output as plain text |
+| tg_output           | Terragrunt output in JSON format|
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -1,37 +1,39 @@
-name: 'Gruntwork Terragrunt'
-description: 'Setup and execute Terragrunt.'
-author:  'Gruntwork'
+name: "Gruntwork Terragrunt"
+description: "Setup and execute Terragrunt."
+author: "Gruntwork"
 
 branding:
-  icon: 'award'
-  color: 'purple'
+  icon: "award"
+  color: "purple"
 
 inputs:
   tg_version:
-    description: 'Terragrunt version to install.'
+    description: "Terragrunt version to install."
     required: true
   tf_version:
-    description: 'Terraform version to install.'
+    description: "Terraform version to install."
     required: true
   tg_command:
-    description: 'Terragrunt command to execute.'
+    description: "Terragrunt command to execute."
     required: true
   tg_dir:
-    description: 'Directory in which Terragrunt will be executed.'
+    description: "Directory in which Terragrunt will be executed."
     required: true
   tg_comment:
-    description: 'Include execution output as comment'
-    default: '0'
+    description: "Include execution output as comment"
+    default: "0"
     required: false
   tg_add_approve:
-    description: 'Add -auto-approve to commands which require changes to be applied'
-    default: '1'
+    description: "Add -auto-approve to commands which require changes to be applied"
+    default: "1"
     required: false
 outputs:
   tg_action_output:
-    description: 'Terragrunt execution output'
+    description: "Terragrunt execution output"
   tg_action_exit_code:
-    description: 'Terragrunt exit code'
+    description: "Terragrunt exit code"
+  tg_output:
+    description: "Terragrunt output"
 runs:
-  using: 'docker'
-  image: './Dockerfile'
+  using: "docker"
+  image: "./Dockerfile"

--- a/action.yml
+++ b/action.yml
@@ -1,39 +1,39 @@
-name: "Gruntwork Terragrunt"
-description: "Setup and execute Terragrunt."
-author: "Gruntwork"
+name: 'Gruntwork Terragrunt'
+description: 'Setup and execute Terragrunt.'
+author:  'Gruntwork'
 
 branding:
-  icon: "award"
-  color: "purple"
+  icon: 'award'
+  color: 'purple'
 
 inputs:
   tg_version:
-    description: "Terragrunt version to install."
+    description: 'Terragrunt version to install.'
     required: true
   tf_version:
-    description: "Terraform version to install."
+    description: 'Terraform version to install.'
     required: true
   tg_command:
-    description: "Terragrunt command to execute."
+    description: 'Terragrunt command to execute.'
     required: true
   tg_dir:
-    description: "Directory in which Terragrunt will be executed."
+    description: 'Directory in which Terragrunt will be executed.'
     required: true
   tg_comment:
-    description: "Include execution output as comment"
-    default: "0"
+    description: 'Include execution output as comment'
+    default: '0'
     required: false
   tg_add_approve:
-    description: "Add -auto-approve to commands which require changes to be applied"
-    default: "1"
+    description: 'Add -auto-approve to commands which require changes to be applied'
+    default: '1'
     required: false
 outputs:
   tg_action_output:
-    description: "Terragrunt execution output"
+    description: 'Terragrunt execution output'
   tg_action_exit_code:
-    description: "Terragrunt exit code"
+    description: 'Terragrunt exit code'
   tg_output:
-    description: "Terragrunt output"
+    description: 'Terragrunt output'
 runs:
-  using: "docker"
-  image: "./Dockerfile"
+  using: 'docker'
+  image: './Dockerfile'

--- a/src/main.sh
+++ b/src/main.sh
@@ -218,6 +218,10 @@ ${terragrunt_output}
   tg_action_output=$(clean_multiline_text "${terragrunt_output}")
   echo "tg_action_output=${tg_action_output}" >> "${GITHUB_OUTPUT}"
 
+  local tg_output
+  tg_output=$(terragrunt output -json 2>/dev/null | jq -c '.')
+  echo "tg_output=${tg_output}" >> "${GITHUB_OUTPUT}"
+
   exit $exit_code
 }
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This PR introduces a new output variable `tg_output` that contains the Terragrunt output in JSON format. This allows users to easily parse and extract specific values from the Terragrunt output using tools like jq within their GitHub Actions workflows.

Example usage:

```yml
- name: Extract test value
  id: extract_test
  run: |
    echo '${{ steps.terragrunt.outputs.tg_output }}'
```

This feature is useful when you need Terragrunt output values for the next steps in your workflow. 
It eliminates the need to hardcode resource names in template files, making your workflow more dynamic and flexible.

In the AWS provider, there are several situations where this feature can be particularly useful
- When using CloudFront, it's often necessary to purge the cache after deploying changes. By extracting the CloudFront distribution's ARN using `tg_output`, you can automate the cache purge process in your workflow.
- In ECS deployments, it's common to wait for the ECS service to stabilize after an update. With `tg_output`, you can easily access the service and cluster names, enabling you to implement a wait step in your workflow.

<!-- Description of the changes introduced by this PR. -->

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Added `tg_output` variable containing Terragrunt output in JSON format.


### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

