### PR TITLE
Add handling of long PR comments

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -90,7 +90,7 @@ function comment {
     return
   fi
   local escaped_message
-  escaped_message=$(printf '%s' "$message" | sed 's/"/\\"/g')
+  escaped_message=$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g')
   local tmpfile
   tmpfile=$(mktemp)
   echo "{\"body\": \"$escaped_message\"}" > "$tmpfile"

--- a/src/main.sh
+++ b/src/main.sh
@@ -89,10 +89,8 @@ function comment {
     log "Skipping comment as there is not comment url"
     return
   fi
-  local escaped_message
-  escaped_message=$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n')
-  local tmpfile
-  tmpfile=$(mktemp)
+  local -r escaped_message=$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n')
+  local -r tmpfile=$(mktemp)
   echo "{\"body\": \"$escaped_message\"}" > "$tmpfile"
   curl -s -S -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d @"$tmpfile" "$comment_url"
   rm "$tmpfile"

--- a/src/main.sh
+++ b/src/main.sh
@@ -89,8 +89,11 @@ function comment {
     log "Skipping comment as there is not comment url"
     return
   fi
-  local -r tmpfile=$(mktemp)
-  echo "{\"body\": \"$message\"}" > "$tmpfile"
+  local escaped_message
+  escaped_message=$(printf '%s' "$message" | sed 's/"/\\"/g')
+  local tmpfile
+  tmpfile=$(mktemp)
+  echo "{\"body\": \"$escaped_message\"}" > "$tmpfile"
   curl -s -S -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d @"$tmpfile" "$comment_url"
   rm "$tmpfile"
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -90,7 +90,7 @@ function comment {
     return
   fi
   local escaped_message
-  escaped_message=$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  escaped_message=$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n')
   local tmpfile
   tmpfile=$(mktemp)
   echo "{\"body\": \"$escaped_message\"}" > "$tmpfile"

--- a/src/main.sh
+++ b/src/main.sh
@@ -89,9 +89,10 @@ function comment {
     log "Skipping comment as there is not comment url"
     return
   fi
-  local messagePayload
-  messagePayload=$(jq -n --arg body "$message" '{ "body": $body }')
-  curl -s -S -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d "$messagePayload" "$comment_url"
+  local -r tmpfile=$(mktemp)
+  echo "{\"body\": \"$message\"}" > "$tmpfile"
+  curl -s -S -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d @"$tmpfile" "$comment_url"
+  rm "$tmpfile"
 }
 
 function setup_git {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Updated GitHub action to handle long PR comments.

Fixes #71.

Example output:

![image](https://github.com/gruntwork-io/terragrunt-action/assets/10694338/a5cc8a58-9efd-490c-9156-19fbcfe2194d)


However, long outputs may be rejected by Github:
```
{
  "message": "Validation Failed",
  "errors": [
    {
      "resource": "IssueComment",
      "code": "unprocessable",
      "field": "data",
      "message": "Body is too long (maximum is 65536 characters)"
    }
  ],
  "documentation_url": "https://docs.github.com/rest/issues/comments#create-an-issue-comment"
}

```

<!-- Description of the changes introduced by this PR. -->

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Updated action comment flow to handle long comments

### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->

