### PR TITLE
fix: tg_comment escaping

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -89,7 +89,7 @@ function comment {
     log "Skipping comment as there is not comment url"
     return
   fi
-  local -r escaped_message=$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n')
+  local -r escaped_message=$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g; s/\t/\\t/g' | tr -d '\n')
   local -r tmpfile=$(mktemp)
   echo "{\"body\": \"$escaped_message\"}" > "$tmpfile"
   curl -s -S -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d @"$tmpfile" "$comment_url"


### PR DESCRIPTION
## Description

When using `tg_command: hclfmt --terragrunt-check --terragrunt-diff` and it finds the following missing brace errors in a workflow, it then errors out when trying to post a comment back to the PR. 

```
time=2025-03-11T15:41:59Z level=error msg=3 errors occurred:
	* /github/workspace/terraform/lab1/flux/terragrunt.hcl:3,11-12: Unclosed configuration block; There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.
	* /github/workspace/terraform/lab2/flux/terragrunt.hcl:3,11-12: Unclosed configuration block; There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.
	* /github/workspace/terraform/lab3/flux/terragrunt.hcl:3,11-12: Unclosed configuration block; There is no closing brace for this block before the end of the file. This may be caused by incorrect brace nesting elsewhere in this file.

time=2025-03-11T15:41:59Z level=error msg=Unable to determine underlying exit code, so Terragrunt will exit with error code 1
{
  "message": "Problems parsing JSON",
  "documentation_url": "https://docs.github.com/rest/issues/comments#create-an-issue-comment",
  "status": "400"
}
```

This PR fixes this and successfully comments back on the source PR.