### PR TITLE
feat: Use 2.1.7 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile used in execution of Github Action
-FROM gruntwork/terragrunt:0.2.0
+FROM gruntwork/terragrunt:2.1.7
 LABEL maintainer="Gruntwork <info@gruntwork.io>"
 
 ENV MISE_CONFIG_DIR=~/.config/mise


### PR DESCRIPTION
## Description

Has the Dockerfile for this action use the `2.1.7` image.

## Release Notes (draft)

Updated the Dockerfile to use the `2.1.7` Terragrunt image as its base.
