### PR TITLE
feat: Remove deprecated variables

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -201,12 +201,20 @@ function main {
   local tg_arg_and_commands="${tg_command}"
   if [[ -n "${tofu_version}" ]]; then
     log "Using OpenTofu"
-    export TERRAGRUNT_TFPATH=tofu
+    if [[ "${tg_version}" > 0.48.5 ]]; then
+      export TG_TF_PATH=tofu
+    else
+      export TERRAGRUNT_TFPATH=tofu
+    fi
   fi
 
   if [[ "$tg_command" == "apply"* || "$tg_command" == "destroy"* || "$tg_command" == "run-all apply"* || "$tg_command" == "run-all destroy"* ]]; then
     export TERRAGRUNT_NON_INTERACTIVE=true
-    export TF_INPUT=false
+    if [[ "${tg_version}" > 0.48.5 ]]; then
+      export TG_NON_INTERACTIVE=true
+    else
+      export TF_INPUT=false
+    fi
     export TF_IN_AUTOMATION=1
 
     if [[ "${tg_add_approve}" == "1" ]]; then

--- a/src/main.sh
+++ b/src/main.sh
@@ -201,12 +201,12 @@ function main {
   local tg_arg_and_commands="${tg_command}"
   if [[ -n "${tofu_version}" ]]; then
     log "Using OpenTofu"
-    export TERRAGRUNT_TFPATH=tofu
+    export TG_TF_PATH=tofu
   fi
 
   if [[ "$tg_command" == "apply"* || "$tg_command" == "destroy"* || "$tg_command" == "run-all apply"* || "$tg_command" == "run-all destroy"* ]]; then
     export TERRAGRUNT_NON_INTERACTIVE=true
-    export TF_INPUT=false
+    export TG_NON_INTERACTIVE=false
     export TF_IN_AUTOMATION=1
 
     if [[ "${tg_add_approve}" == "1" ]]; then

--- a/src/main.sh
+++ b/src/main.sh
@@ -201,12 +201,12 @@ function main {
   local tg_arg_and_commands="${tg_command}"
   if [[ -n "${tofu_version}" ]]; then
     log "Using OpenTofu"
-    export TG_TF_PATH=tofu
+    export TERRAGRUNT_TFPATH=tofu
   fi
 
   if [[ "$tg_command" == "apply"* || "$tg_command" == "destroy"* || "$tg_command" == "run-all apply"* || "$tg_command" == "run-all destroy"* ]]; then
     export TERRAGRUNT_NON_INTERACTIVE=true
-    export TG_NON_INTERACTIVE=false
+    export TF_INPUT=false
     export TF_IN_AUTOMATION=1
 
     if [[ "${tg_add_approve}" == "1" ]]; then


### PR DESCRIPTION
## Description

Remove deprecated variables

BREAKING CHANGE: Terragrunt on any consumer using version <= v0.48.6 will cease to behave as expected.

## Release Notes (draft)

- Removed TF_INPUT in favor of TG_NON_INTERACTIVE

- Removed TERRAGRUNT_TFPATH in favor of TG_TF_PATH


### Migration Guide

Update to Terragrunt >= v0.48.6

