### PR TITLE
Allow for tofu_version to be optional when tf_path is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ The current minimum supported version of Terragrunt is 0.77.22.
 
 Supported GitHub action inputs:
 
-| Input Name     | Description                                                       | Required                                  | Example values |
-|:---------------|:------------------------------------------------------------------|:-----------------------------------------:|:--------------:|
-| tg_version     | Terragrunt version to be used in Action execution                | `true` if no `mise.toml` file present    |     0.50.8     |
-| tofu_version   | OpenTofu version to be used in Action execution                  | `true` if no `mise.toml` file present    |     1.6.0      |
-| tf_path        | Path to Terraform binary (use to explicitly choose tofu/terraform) | `false`                                 | /usr/bin/tofu  |
-| tg_dir         | Directory in which Terragrunt will be invoked                     | `false`                                  |      work      |
-| tg_command     | Terragrunt command to execute                                     | `false`                                  |   plan/apply   |
-| tg_comment     | Add comment to Pull request with execution output                 | `false`                                  |      0/1       |
-| tg_add_approve | Automatically add "-auto-approve" to commands, enabled by default | `false`                                  |      0/1       |
-| github_token   | GitHub token for API authentication to avoid rate limits          | `false`                                  | ${{ github.token }} |
+| Input Name     | Description                                                        | Required                                                                    | Example values      |
+|:---------------|:-------------------------------------------------------------------|:---------------------------------------------------------------------------:|:-------------------:|
+| tg_version     | Terragrunt version to be used in Action execution                  | `true` if no `mise.toml` file present                                       |     0.50.8          |
+| tofu_version   | OpenTofu version to be used in Action execution                    | `true` if `tf_path` is not provided ant the file `mise.toml` is not present |     1.6.0           |
+| tf_path        | Path to Terraform binary (use to explicitly choose tofu/terraform) | `false`                                                                     | /usr/bin/tofu       |
+| tg_dir         | Directory in which Terragrunt will be invoked                      | `false`                                                                     |      work           |
+| tg_command     | Terragrunt command to execute                                      | `false`                                                                     |   plan/apply        |
+| tg_comment     | Add comment to Pull request with execution output                  | `false`                                                                     |      0/1            |
+| tg_add_approve | Automatically add "-auto-approve" to commands, enabled by default  | `false`                                                                     |      0/1            |
+| github_token   | GitHub token for API authentication to avoid rate limits           | `false`                                                                     | ${{ github.token }} |
 
 ## Tool Version Management
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
       id: mise-check
       shell: bash
       env:
+        INPUT_TF_PATH: ${{ inputs.tf_path }}
         INPUT_TG_VERSION: ${{ inputs.tg_version }}
         INPUT_TOFU_VERSION: ${{ inputs.tofu_version }}
       run: |
@@ -63,8 +64,8 @@ runs:
             exit 1
           fi
 
-          if [[ -z "${INPUT_TOFU_VERSION}" ]]; then
-            echo "ERROR: No mise.toml found, making 'tofu_version' required"
+         if [[ -z "${INPUT_TOFU_VERSION}" && -z "${INPUT_TF_PATH}" ]]; then
+            echo "ERROR: No mise.toml found, so 'tofu_version' is required unless 'tf_path' is provided."
             exit 1
           fi
         fi


### PR DESCRIPTION
## Description

With the recent 3.0.0 release. It is required to provide a tofu_version input or add a mise.toml file. Which unfriendly to consumers using only terraform and not using a mise.toml file.

This PR attempts to make it easier for users of terraform by making the tofu_version input optional when the tf_path input is provided. Enabling users of terraform to install terraform outside of this action and provide the path as either 'terraform' or as a absolute path to their installation. 

## Release Notes (draft)

Added / Removed / Updated [X].
Update tofu_version to be optional when tf_path is provided. 

### Migration Guide

N/A

