### PR TITLE
enhance: support both boolean and numeric values for tg_comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
   tg_comment:
     description: 'Include execution output as comment'
-    default: '0'
+    default: "false"
     required: false
   tg_add_approve:
     description: 'Add -auto-approve to commands which require it when not running interactively'

--- a/src/main.sh
+++ b/src/main.sh
@@ -177,7 +177,7 @@ function main {
   local terragrunt_output
   terragrunt_output=$(clean_colors "${terragrunt_log_content}")
 
-  if [[ "${tg_comment}" == "1" ]]; then
+  if [[ "${tg_comment}" == "1" || "${tg_comment}" == "true" ]]; then
     comment "<details>
 <summary>Execution result of \"$tg_command\" in \"${tg_dir}\"</summary>
 


### PR DESCRIPTION
## Description

Fixes #19.

- Updated tg_comment condition to accept both "1" and "true" as valid values
- Changed default from '0' to "false" for better boolean semantics
- Maintains backward compatibility while providing intuitive boolean interface

## Release Notes (draft)

Added support for true/false for tg_comment .

### Migration Guide

None, it's backwards compatible.