### PR TITLE
Only have mise install the necessary tools

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -86,6 +86,7 @@ runs:
         tool_versions: |
           terragrunt ${{ inputs.tg_version }}
           ${{ inputs.tofu_version && format('opentofu {0}', inputs.tofu_version) || '' }}
+        install_args: "terragrunt ${{ inputs.tofu_version && 'opentofu' || '' }}"
       env:
         MISE_GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
 


### PR DESCRIPTION
## Description

Fixes #115.

Updates the call to jdx/mise-action to only install the tools used by terragrunt-action

## Release Notes (draft)

Updated mise install to only install necessary tools.

### Migration Guide

N/A
