### PR TITLE
fix: generate local mise.toml config when tf/tofu_version inputs are set

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:docs.github.com)",
+      "WebFetch(domain:github.blog)",
+      "WebSearch",
+      "WebFetch(domain:github.com)",
+      "Bash(bash -n /Users/tensho/Projects/oss/terragrunt-action/src/main.sh)",
+      "Bash(python3 *)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ The current minimum supported version of Terragrunt is 0.77.22.
 
 Supported GitHub action inputs:
 
-| Input Name        | Description                                                                                | Required                                                                    | Example values      |
-|:------------------|:-------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------|:--------------------|
-| tg_version        | Terragrunt version to be used in Action execution                                          | `true` if no `mise.toml` file present                                       | 0.50.8              |
-| tofu_version      | OpenTofu version to be used in Action execution                                            | `true` if `tf_path` is not provided and the file `mise.toml` is not present | 1.6.0               |
-| tf_path           | Path to Terraform binary (use to explicitly choose tofu/terraform)                         | `false`                                                                     | /usr/bin/tofu       |
-| tg_dir            | Directory in which Terragrunt will be invoked                                              | `false`                                                                     | work                |
-| tg_command        | Terragrunt command to execute                                                              | `false`                                                                     | plan/apply          |
-| tg_comment        | Add comment to Pull request with execution output                                          | `false`                                                                     | 0/1                 |
-| tg_add_approve    | Automatically add "-auto-approve" to commands, enabled by default                          | `false`                                                                     | 0/1                 |
-| tg_output_capture | Capture Terragrunt execution output, enabled by default. Set to `0` for very large outputs | `false`                                                                     | 0/1                 |
-| github_token      | GitHub token for API authentication to avoid rate limits                                   | `false`                                                                     | ${{ github.token }} |
+| Input Name        | Description                                                                                | Required                                         | Example values      |
+|:------------------|:-------------------------------------------------------------------------------------------|:-------------------------------------------------|:--------------------|
+| tf_version        | Terraform version to be used in Action execution                                           | `false` (`tf_path` or `mise.toml` are expected)  |     1.6.0           |
+| tofu_version      | OpenTofu version to be used in Action execution                                            | `false` (`tf_path` or `mise.toml` are expected)  | 1.6.0               |
+| tg_version        | Terragrunt version to be used in Action execution                                          | `false` (`mise.toml` is expected)                | 0.50.8              |
+| tf_path           | Path to Terraform binary (use to explicitly choose tofu/terraform)                         | `false`                                          | /usr/bin/tofu       |
+| tg_dir            | Directory in which Terragrunt will be invoked                                              | `false`                                          | work                |
+| tg_command        | Terragrunt command to execute                                                              | `false`                                          | plan/apply          |
+| tg_comment        | Add comment to Pull request with execution output                                          | `false`                                          | 0/1                 |
+| tg_add_approve    | Automatically add "-auto-approve" to commands, enabled by default                          | `false`                                          | 0/1                 |
+| tg_output_capture | Capture Terragrunt execution output, enabled by default. Set to `0` for very large outputs | `false`                                          | 0/1                 |
+| github_token      | GitHub token for API authentication to avoid rate limits                                   | `false`                                          | ${{ github.token }} |
 
 ## Tool Version Management
 

--- a/action.yml
+++ b/action.yml
@@ -59,9 +59,9 @@ runs:
         version: 2025.6.8
         mise_toml: |
           [tools]
-          ${{ inputs.tg_version && format('terragrunt = {0}', inputs.tg_version) || '' }}
-          ${{ inputs.tf_version && format('terraform = {0}', inputs.tf_version) || '' }}
-          ${{ inputs.tofu_version && format('opentofu = {0}', inputs.tofu_version) || '' }}
+          ${{ inputs.tg_version && format('terragrunt = "{0}"', inputs.tg_version) || '' }}
+          ${{ inputs.tf_version && format('terraform = "{0}"', inputs.tf_version) || '' }}
+          ${{ inputs.tofu_version && format('opentofu = "{0}"', inputs.tofu_version) || '' }}
         github_token: ${{ inputs.github_token || github.token }}
 
     - name: Execute Terragrunt

--- a/action.yml
+++ b/action.yml
@@ -8,13 +8,16 @@ branding:
 
 inputs:
   tg_version:
-    description: 'Terragrunt version to install (required if no mise.toml file present).'
+    description: 'Terragrunt version to install (overrides mise.toml config file).'
+    required: false
+  tf_version:
+    description: 'Terraform version to install (overrides mise.toml config file).'
     required: false
   tofu_version:
-    description: 'OpenTofu version to install (required if no mise.toml and tf_version not set).'
+    description: 'OpenTofu version to install (overrides mise.toml config file).'
     required: false
   tf_path:
-    description: 'Path to Terraform binary to use. This is typically used to explicitly decide to use tofu or terraform when both are installed.'
+    description: 'Path to Terraform/OpenTofu binary to use. This is typically used to explicitly decide what binary to use when both are installed.'
     required: false
   tg_command:
     description: 'Terragrunt command to execute.'
@@ -49,49 +52,17 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Check for mise.toml and validate inputs
-      id: mise-check
-      shell: bash
-      env:
-        INPUT_TF_PATH: ${{ inputs.tf_path }}
-        INPUT_TG_VERSION: ${{ inputs.tg_version }}
-        INPUT_TOFU_VERSION: ${{ inputs.tofu_version }}
-      run: |
-        if [[ -f "mise.toml" || -f ".mise.toml" ]]; then
-          echo "mise_config_exists=true" >> $GITHUB_OUTPUT
-          echo "Found mise configuration file, will use it for tool versions"
-        else
-          echo "mise_config_exists=false" >> $GITHUB_OUTPUT
-
-          if [[ -z "${INPUT_TG_VERSION}" ]]; then
-            echo "ERROR: No mise.toml found, making 'tg_version' required."
-            exit 1
-          fi
-
-         if [[ -z "${INPUT_TOFU_VERSION}" && -z "${INPUT_TF_PATH}" ]]; then
-            echo "ERROR: No mise.toml found, so 'tofu_version' is required unless 'tf_path' is provided."
-            exit 1
-          fi
-        fi
-
-    - name: Install tools with mise (using mise.toml)
-      if: steps.mise-check.outputs.mise_config_exists == 'true'
+    - name: Install tools
+      if: ${{ inputs.tf_path == '' }}
       uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4
       with:
-        version: 2026.3.9
-      env:
-        MISE_GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
-
-    - name: Install tools with mise (using input versions)
-      if: steps.mise-check.outputs.mise_config_exists == 'false'
-      uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4
-      with:
-        version: 2026.3.9
-        tool_versions: |
-          terragrunt ${{ inputs.tg_version }}
-          ${{ inputs.tofu_version && format('opentofu {0}', inputs.tofu_version) || '' }}
-      env:
-        MISE_GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
+        version: 2025.6.8
+        mise_toml: |
+          [tools]
+          ${{ inputs.tg_version && format('terragrunt = {0}', inputs.tg_version) || '' }}
+          ${{ inputs.tf_version && format('terraform = {0}', inputs.tf_version) || '' }}
+          ${{ inputs.tofu_version && format('opentofu = {0}', inputs.tofu_version) || '' }}
+        github_token: ${{ inputs.github_token || github.token }}
 
     - name: Execute Terragrunt
       if: ${{ inputs.tg_command != '' }}


### PR DESCRIPTION
## Description

The current [`mise.toml` config file presence check](https://github.com/gruntwork-io/terragrunt-action/blob/main/action.yml#L56) doesn't look up to the repository root:
```
# infrastructure estate repo
path
└─to
  └─unit               <=== when working directory is set here
    └─ terragrunt.hcl
mise.toml              <=== shell check can't find it within the scope of the unit directory
```
Hence, error like this come up:

<img width="1778" height="199" alt="image" src="https://github.com/user-attachments/assets/b4b9963c-43e0-4749-9777-41a295b886a2" />


I guess there was an assumption that action should always target repo root, not a unit folder. In contrast, [`mise` looks up config file hierarchically](https://mise.jdx.dev/configuration.html#configuration-hierarchy), which is expected behaviour for those who rely on this dev tool. This PR preserves `tf_version`/`tofu_version` action inputs precedence over `mise.toml`, but with mise-native approach:

1. If `tf_version`/`tofu_version` input variable is set, no matter of `mise.toml` config file presence (at any level) – generate local `mise.toml` config file and let `mise` look it up and use.
2. If `tf_version`/`tofu_version` input variable is not set, but `mise.toml` config files is present (not necessary at the root, anywhere upwards the current working directory) – let `mise` look it up and use.
3. If `tf_version`/`tofu_version` input variable is not set and `mise.toml` config files is present – let `mise` install the latest version.

This behaviour is intuitive  in terms of tool versions resolution.

## Release Notes (draft)

```
Added

`tf_version` action input to specify Terraform version

Updated

Handle `mise.toml` config file at any level (not only at root) with mise native hierarchical lookup
```

### Migration Guide

N/A

### Notes

* Added `tf_version` action input to specify desired Terraform version. I don't know why it has been removed in v3, TBH. Happy to yank it if you want to preserve `tofu_version` + `tf_path` interface **exclusively**.
* Updates [`jdx/mise-action`](https://github.com/jdx/mise-action/releases) from `v2` to `v3`. There are no breaking changes.
* Replaced `MISE_GITHUB_TOKEN` environment variable with `github_token` action input as the former one is not supported ([code search](https://github.com/search?q=repo%3Ajdx%2Fmise-action%20MISE_GITHUB_TOKEN&type=code))

P.S. I like the tools versioning shift towards `mise` and I appreciate there is an option for it 👍 