### PR TITLE
Update mise version to 2025.12.12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
       if: steps.mise-check.outputs.mise_config_exists == 'true'
       uses: jdx/mise-action@v2
       with:
-        version: 2025.6.8
+        version: 2025.12.12
       env:
         MISE_GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
 
@@ -82,7 +82,7 @@ runs:
       if: steps.mise-check.outputs.mise_config_exists == 'false'
       uses: jdx/mise-action@v2
       with:
-        version: 2025.6.8
+        version: 2025.12.12
         tool_versions: |
           terragrunt ${{ inputs.tg_version }}
           ${{ inputs.tofu_version && format('opentofu {0}', inputs.tofu_version) || '' }}


### PR DESCRIPTION
## Description

Solves https://github.com/gruntwork-io/terragrunt-action/issues/123

Bumps the hard coded version of `mise` to the current latest.

The existing terragrunt-action fails in my workflow, seemingly, because an old version of `mise` cannot tries and fails to fetch the correct packages when installing the Terraform and Terragrunt.

The actual failure in GH Actions

```
Running mise install 
  /home/runner/.local/share/mise/bin/mise install
  DEBUG Version: 2025.6.8 linux-x64 (2025-06-26)
  DEBUG ARGS: /home/runner/.local/share/mise/bin/mise install
  WARN  deprecated [idiomatic_version_file_enable_tools]: 
  Idiomatic version files like ~/work/Terraform/Terraform/.python-version are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
  
  You can remove this warning by explicitly enabling idiomatic version files for python with:
  
      mise settings add idiomatic_version_file_enable_tools python
  
  You can disable idiomatic version files with:
  
      mise settings add idiomatic_version_file_enable_tools "[]"
  
  See https://github.com/jdx/mise/discussions/4345 for more information.
  DEBUG config: ~/work/Terraform/Terraform/mise.toml
  DEBUG config: ~/work/Terraform/Terraform/.python-version
  DEBUG GET http://mise-versions.jdx.dev/terragrunt
  DEBUG starting new connection: http://mise-versions.jdx.dev/
  DEBUG GET http://mise-versions.jdx.dev/terragrunt 200 OK
  DEBUG GET http://mise-versions.jdx.dev/terraform
  DEBUG GET http://mise-versions.jdx.dev/terraform 200 OK
  DEBUG Installing python-build to /home/runner/.cache/mise/python/pyenv
  DEBUG cloning https://github.com/pyenv/pyenv.git to /home/runner/.cache/mise/python/pyenv with gix
  DEBUG starting new connection: https://github.com/
  DEBUG $ /home/runner/.cache/mise/python/pyenv/plugins/python-build/bin/python-build --definitions
  DEBUG install_some_versions: terragrunt@0.93.2 terraform@1.13.5 python@3.13
  INFO  terraform@1.13.5 install
  INFO  python@3.13.11  install
  DEBUG GET http://mise-versions.jdx.dev/python-precompiled-x86_64-unknown-linux-gnu.gz
  DEBUG GET https://api.github.com/repos/hashicorp/terraform/releases
  DEBUG starting new connection: https://api.github.com/
  INFO  terragrunt@0.93.2 install
  DEBUG GET http://mise-versions.jdx.dev/python-precompiled-x86_64-unknown-linux-gnu.gz 400 Bad Request
  DEBUG GET https://mise-versions.jdx.dev/python-precompiled-x86_64-unknown-linux-gnu.gz
  DEBUG starting new connection: https://mise-versions.jdx.dev/
  DEBUG GET https://mise-versions.jdx.dev/python-precompiled-x86_64-unknown-linux-gnu.gz 400 Bad Request
  Error: 
     0: failed to install core:python@3.13.11
     1: HTTP status client error (400 Bad Request) for url (https://mise-versions.jdx.dev/python-precompiled-x86_64-unknown-linux-gnu.gz)
  
  Location:
     src/http.rs:78
  
  Version:
     2025.6.8 linux-x64 (2025-06-26)
  
  Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
  Run with RUST_BACKTRACE=full to include source snippets.
  ::endgroup::
```

The important thing is my repo has a `mise.toml` and a `.python-version` file. In CICD, I don't need to install python and the new behaviour (from 2025.10.0 onwards) will not install based on the `.python-version` file. This means when `mise` does not try to fetch Python.

Python is not needed in my GItHub Action workflow as I am simply running terraform/terragrunt format.

I have pointed my workflow to this forked github action and it solves my specific problem.

## Release Notes (draft)

Updated mise version to 2025.12.12

