### PR TITLE
feat: allowing mise to be disabled

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,9 @@
 name: 'Gruntwork Terragrunt'
 description: 'Setup and execute Terragrunt.'
-author:  'Gruntwork'
-
+author: 'Gruntwork'
 branding:
   icon: 'award'
   color: 'purple'
-
 inputs:
   tg_version:
     description: 'Terragrunt version to install (required if no mise.toml file present).'
@@ -33,7 +31,6 @@ inputs:
   github_token:
     description: 'GitHub token for API authentication to avoid rate limits when installing tools'
     required: false
-
 outputs:
   tg_action_output:
     description: 'Terragrunt execution output'
@@ -41,7 +38,6 @@ outputs:
   tg_action_exit_code:
     description: 'Terragrunt exit code'
     value: ${{ steps.terragrunt-exec.outputs.tg_action_exit_code }}
-
 runs:
   using: 'composite'
   steps:
@@ -53,7 +49,7 @@ runs:
         INPUT_TG_VERSION: ${{ inputs.tg_version }}
         INPUT_TOFU_VERSION: ${{ inputs.tofu_version }}
       run: |
-        if [[ -f "mise.toml" || -f ".mise.toml" ]]; then
+        if [[ -z "$INPUT_TG_VERSION" && -z "$INPUT_TF_PATH" && ( -f "mise.toml" || -f ".mise.toml" ) ]]; then
           echo "mise_config_exists=true" >> $GITHUB_OUTPUT
           echo "Found mise configuration file, will use it for tool versions"
         else
@@ -69,7 +65,6 @@ runs:
             exit 1
           fi
         fi
-
     - name: Install tools with mise (using mise.toml)
       if: steps.mise-check.outputs.mise_config_exists == 'true'
       uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4
@@ -77,7 +72,6 @@ runs:
         version: 2026.3.9
       env:
         MISE_GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
-
     - name: Install tools with mise (using input versions)
       if: steps.mise-check.outputs.mise_config_exists == 'false'
       uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4
@@ -88,7 +82,6 @@ runs:
           ${{ inputs.tofu_version && format('opentofu {0}', inputs.tofu_version) || '' }}
       env:
         MISE_GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
-
     - name: Execute Terragrunt
       if: ${{ inputs.tg_command != '' }}
       id: terragrunt-exec


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

We use a monorepo with a whole structure of mise files for tooling. We do not want to install all of our tooling just to run terraform. I initially added a boolean flag to disable mise, but figured it was better just to use an implicit condition. If you set both the TG version AND the TF path, then we no longer use mise. This does change the current functionality by making it implicit, so if its better to use an additional flag with a default, I'm more than willing to go that route.

<!-- Description of the changes introduced by this PR. -->

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added ability to disable mise integration

### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-version configuration detection: the action now uses `mise.toml` only when no explicit tool versions are provided (including when related version inputs are left empty).
* **Style**
  * Standardized action metadata formatting and spacing.
  * Reformatted action output declarations for cleaner layout.
* **Chores**
  * Updated tool installation to use the `@v4` tag instead of a pinned commit, and removed the now-unneeded version parameter (while preserving `tool_versions` handling when inputs are provided).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->