### PR TITLE
feat: add optional terragrunt output capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,17 @@ The current minimum supported version of Terragrunt is 0.77.22.
 
 Supported GitHub action inputs:
 
-| Input Name     | Description                                                        | Required                                                                    | Example values      |
-|:---------------|:-------------------------------------------------------------------|:---------------------------------------------------------------------------:|:-------------------:|
-| tg_version     | Terragrunt version to be used in Action execution                  | `true` if no `mise.toml` file present                                       |     0.50.8          |
-| tofu_version   | OpenTofu version to be used in Action execution                    | `true` if `tf_path` is not provided and the file `mise.toml` is not present |     1.6.0           |
-| tf_path        | Path to Terraform binary (use to explicitly choose tofu/terraform) | `false`                                                                     | /usr/bin/tofu       |
-| tg_dir         | Directory in which Terragrunt will be invoked                      | `false`                                                                     |      work           |
-| tg_command     | Terragrunt command to execute                                      | `false`                                                                     |   plan/apply        |
-| tg_comment     | Add comment to Pull request with execution output                  | `false`                                                                     |      0/1            |
-| tg_add_approve | Automatically add "-auto-approve" to commands, enabled by default  | `false`                                                                     |      0/1            |
-| github_token   | GitHub token for API authentication to avoid rate limits           | `false`                                                                     | ${{ github.token }} |
+| Input Name        | Description                                                                                | Required                                                                    | Example values      |
+|:------------------|:-------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------|:--------------------|
+| tg_version        | Terragrunt version to be used in Action execution                                          | `true` if no `mise.toml` file present                                       | 0.50.8              |
+| tofu_version      | OpenTofu version to be used in Action execution                                            | `true` if `tf_path` is not provided and the file `mise.toml` is not present | 1.6.0               |
+| tf_path           | Path to Terraform binary (use to explicitly choose tofu/terraform)                         | `false`                                                                     | /usr/bin/tofu       |
+| tg_dir            | Directory in which Terragrunt will be invoked                                              | `false`                                                                     | work                |
+| tg_command        | Terragrunt command to execute                                                              | `false`                                                                     | plan/apply          |
+| tg_comment        | Add comment to Pull request with execution output                                          | `false`                                                                     | 0/1                 |
+| tg_add_approve    | Automatically add "-auto-approve" to commands, enabled by default                          | `false`                                                                     | 0/1                 |
+| tg_output_capture | Capture Terragrunt execution output, enabled by default. Set to `0` for very large outputs | `false`                                                                     | 0/1                 |
+| github_token      | GitHub token for API authentication to avoid rate limits                                   | `false`                                                                     | ${{ github.token }} |
 
 ## Tool Version Management
 
@@ -54,7 +55,7 @@ Outputs of GitHub action:
 | Input Name          | Description                     |
 |:--------------------|:--------------------------------|
 | tg_action_exit_code | Terragrunt exit code            |
-| tg_action_output    | Terragrunt output as plain text |
+| tg_action_output    | Terragrunt output as plain text. Only emitted when `tg_output_capture` is `1` (the default) |
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: 'Add -auto-approve to commands which require it when not running interactively'
     default: '1'
     required: false
+  tg_output_capture:
+    description: 'Capture Terragrunt execution output as the `tg_action_output` action output'
+    default: '1'
+    required: false
   github_token:
     description: 'GitHub token for API authentication to avoid rate limits when installing tools'
     required: false
@@ -102,3 +106,4 @@ runs:
         INPUT_TG_DIR: ${{ inputs.tg_dir }}
         INPUT_TG_COMMENT: ${{ inputs.tg_comment }}
         INPUT_TG_ADD_APPROVE: ${{ inputs.tg_add_approve }}
+        INPUT_TG_OUTPUT_CAPTURE: ${{ inputs.tg_output_capture }}

--- a/src/main.sh
+++ b/src/main.sh
@@ -135,6 +135,7 @@ function main {
   local -r tg_command=${INPUT_TG_COMMAND}
   local -r tg_comment=${INPUT_TG_COMMENT:-0}
   local -r tg_add_approve=${INPUT_TG_ADD_APPROVE:-1}
+  local -r tg_output_capture=${INPUT_TG_OUTPUT_CAPTURE:-1}
   local -r tg_dir=${INPUT_TG_DIR:-${GITHUB_WORKSPACE}} # use GitHub workspace as default
 
   if [[ -z "${tg_command}" ]]; then
@@ -191,9 +192,13 @@ ${terragrunt_output}
 
   echo "tg_action_exit_code=${exit_code}" >> "${GITHUB_OUTPUT}"
 
-  local tg_action_output
-  tg_action_output=$(clean_multiline_text "${terragrunt_output}")
-  echo "tg_action_output=${tg_action_output}" >> "${GITHUB_OUTPUT}"
+  if [[ "${tg_output_capture}" == "1" ]]; then
+    local tg_action_output
+    tg_action_output=$(clean_multiline_text "${terragrunt_output}")
+    echo "tg_action_output=${tg_action_output}" >> "${GITHUB_OUTPUT}"
+  else
+    log "Skipping tg_action_output capture (tg_output_capture=${tg_output_capture})"
+  fi
 
   exit $exit_code
 }


### PR DESCRIPTION
## Description

Fixes #118

This change aims to condition Terragrunt output propagation to step outputs preserving current behaviour. 

## Problem Statement

Sometimes Terragrunt output could be huge and workflow fails with the next error:
```
Error: The template is not valid. System.InvalidOperationException: Maximum object size exceeded
```

The `echo … >> $GITHUB_OUTPUT` itself writes successfully. The runtime crash happens after `main.sh` exits, when the Actions template evaluator has to materialize `${{ steps.terragrunt-exec.outputs.tg_action_output }}` to populate the composite action's `outputs.tg_action_output.value`. The evaluator builds an in-memory object model of the workflow tree, which has a hard cap on object size. A multi-megabyte string node trips that cap. So:
* `action.yml` promises to surface the entire Terragrunt log as an action output
* `main.sh` dutifully writes it to the outputs environment
* runner explodes when wiring the inner step output to the outer action output

The error message The template is not valid is misleading (the YAML is valid); it's really a runtime serialisation limit on the value being plumbed through the template object.

## Solution

The `tg_output_capture` toggle controls this behaviour:
| `tg_output_capture` | `tg_action_output` |
|--------|--------|
| 0 | Action doesn't save Terragrunt command execution output to the output variable |
| 1 (default) | Action saves Terragrunt command execution output to the output variable |

## Considerations

The current change patches the issue but there are more sustainable options to this quite common issue (huge action artifacts), however they imply breaking change due to the interface shift:

1. **Truncate**. Keep the tail (where plan summaries live), prefix with a truncated marker. Cons: people doing string-matching on the output will get surprised when their match disappears in the truncated half.
1. **File path**. Don't put the log content in `$GITHUB_OUTPUT` rather copy the temp log to a stable location (e.g. `${RUNNER_TEMP}/terragrunt-output.log`) and expose `tg_action_output_path` output. Cons: cross-job consumers (artifact upload) need an extra step; a hard breaking change.
1. **`$GITHUB_STEP_SUMMARY`** mirror. For UI visibility, write the (possibly trimmed) Terragrunt output to `$GITHUB_STEP_SUMMARY` (["Adding job summary"](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-job-summary)). Independent of the output-capture decision. Has its own 1 MB cap per step, but doesn't go through template evaluation, so it tolerates more.
1. **Percent-encoding drop**. Switch to the modern heredoc form in `$GITHUB_OUTPUT`:

        {
          echo "tg_action_output<<EOF_TG_OUTPUT_$$"
          printf '%s\n' "${terragrunt_output}"
          echo "EOF_TG_OUTPUT_$$"
        } >> "${GITHUB_OUTPUT}"
    
    Lines stay as lines, ~3x smaller than the percent-encoded version, and downstream `${{ steps.x.outputs.tg_action_output }}` returns the original text instead of %0A-encoded soup. Doesn't fix the burst on its own (the giant value still hits the template evaluator), but worth doing alongside any other fix and may be enough to push borderline cases under the cap.

Also, I thought about re-using `tg_comment` input variable as a toggle but gave it up in favor no breaking changes in interface.

If Gruntwork maintainers feel strong about any of this options, I'm more than happy to implement them and cut of a major release.

## Testing

I've tested it in our org GitHub Actions:

<img width="2061" height="852" alt="image" src="https://github.com/user-attachments/assets/6689b3de-8d75-401c-a490-7de568428a4a" />

vs

<img width="2070" height="888" alt="image" src="https://github.com/user-attachments/assets/bcb45bd8-807c-435b-acab-04a23ffead78" />

## Release Notes (draft)

* Added `tg_output_capture` toggle to control Terragrunt execution output propagation to the step outputs

### Migration Guide

N/A
