### PR TITLE
allow installing terraform with mise

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,10 @@ inputs:
     description: 'Terragrunt version to install (required if no mise.toml file present).'
     required: false
   tofu_version:
-    description: 'OpenTofu version to install (required if no mise.toml and tf_version not set).'
+    description: 'OpenTofu version to install (required if neither mise.toml nor .mise.toml exists, and tf_version/tf_path are not set).'
+    required: false
+  tf_version:
+    description: 'Terraform version to install (required if neither mise.toml nor .mise.toml exists, and tofu_version/tf_path are not set).'
     required: false
   tf_path:
     description: 'Path to Terraform binary to use. This is typically used to explicitly decide to use tofu or terraform when both are installed.'
@@ -59,6 +62,7 @@ runs:
         INPUT_TF_PATH: ${{ inputs.tf_path }}
         INPUT_TG_VERSION: ${{ inputs.tg_version }}
         INPUT_TOFU_VERSION: ${{ inputs.tofu_version }}
+        INPUT_TF_VERSION: ${{ inputs.tf_version }}
       run: |
         if [[ -f "mise.toml" || -f ".mise.toml" ]]; then
           echo "mise_config_exists=true" >> $GITHUB_OUTPUT
@@ -71,8 +75,13 @@ runs:
             exit 1
           fi
 
-         if [[ -z "${INPUT_TOFU_VERSION}" && -z "${INPUT_TF_PATH}" ]]; then
-            echo "ERROR: No mise.toml found, so 'tofu_version' is required unless 'tf_path' is provided."
+          if [[ -n "${INPUT_TOFU_VERSION}" && -n "${INPUT_TF_VERSION}" ]]; then
+            echo "ERROR: 'tofu_version' and 'tf_version' are mutually exclusive. Set only one, or use 'tf_path'."
+            exit 1
+          fi
+
+          if [[ -z "${INPUT_TOFU_VERSION}" && -z "${INPUT_TF_VERSION}" && -z "${INPUT_TF_PATH}" ]]; then
+            echo "ERROR: No mise.toml found, so one of 'tofu_version', 'tf_version', or 'tf_path' is required."
             exit 1
           fi
         fi
@@ -93,6 +102,7 @@ runs:
         tool_versions: |
           terragrunt ${{ inputs.tg_version }}
           ${{ inputs.tofu_version && format('opentofu {0}', inputs.tofu_version) || '' }}
+          ${{ inputs.tf_version && format('terraform {0}', inputs.tf_version) || '' }}
       env:
         MISE_GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
 

--- a/test/action_run_test.go
+++ b/test/action_run_test.go
@@ -132,14 +132,25 @@ else
     exit 1
   fi
 
-  if [[ -z "${INPUT_TOFU_VERSION}" ]]; then
-    echo "ERROR: No mise.toml found, making 'tofu_version' required"
+  if [[ -n "${INPUT_TOFU_VERSION}" && -n "${INPUT_TF_VERSION}" ]]; then
+    echo "ERROR: 'tofu_version' and 'tf_version' are mutually exclusive. Set only one, or use 'tf_path'."
+    exit 1
+  fi
+
+  if [[ -z "${INPUT_TOFU_VERSION}" && -z "${INPUT_TF_VERSION}" && -z "${INPUT_TF_PATH}" ]]; then
+    echo "ERROR: No mise.toml found, so one of 'tofu_version', 'tf_version', or 'tf_path' is required."
     exit 1
   fi
 fi
 
 echo "=== Installing tools with mise ==="
-echo "Would install: terragrunt ${INPUT_TG_VERSION}, opentofu ${INPUT_TOFU_VERSION}"
+if [[ -n "${INPUT_TOFU_VERSION}" ]]; then
+  echo "Would install: terragrunt ${INPUT_TG_VERSION}, opentofu ${INPUT_TOFU_VERSION}"
+elif [[ -n "${INPUT_TF_VERSION}" ]]; then
+  echo "Would install: terragrunt ${INPUT_TG_VERSION}, terraform ${INPUT_TF_VERSION}"
+else
+  echo "Would install: terragrunt ${INPUT_TG_VERSION}"
+fi
 
 if [[ -n "${INPUT_TG_COMMAND}" ]]; then
   echo "=== Executing Terragrunt ==="
@@ -167,6 +178,9 @@ fi
 	}
 	if iacVersion != "" && iacType == "tofu" {
 		env = append(env, "INPUT_TOFU_VERSION="+iacVersion)
+	}
+	if iacVersion != "" && iacType == "tf" {
+		env = append(env, "INPUT_TF_VERSION="+iacVersion)
 	}
 	if command != "" {
 		env = append(env, "INPUT_TG_COMMAND="+command)


### PR DESCRIPTION
## Description

currently, we support installing opentofu either via a mise.toml file or by specifying tofu_version. For terraform, only mise.toml is supported.

Add a tf_version parameter that acts the same as tofu_version to allow using terraform instead.

fixes #138

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
add `tf_version` parameter to specify Terraform version.

### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated public input descriptions for Terraform and OpenTofu version settings to reflect the correct conditional requirements when no mise configuration file is present.
* **Bug Fixes / Chores**
  * Improved validation for version inputs, including rejecting cases where both version inputs are set together.
  * Adjusted error conditions and tool version selection so Terraform is included only when its version is specified in the no-mise-config scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->