### PR TITLE
support .tool-versions files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Check for mise.toml and validate inputs
+    - name: Check for mise configuration files and validate inputs
       id: mise-check
       shell: bash
       env:
@@ -60,7 +60,7 @@ runs:
         INPUT_TG_VERSION: ${{ inputs.tg_version }}
         INPUT_TOFU_VERSION: ${{ inputs.tofu_version }}
       run: |
-        if [[ -f "mise.toml" || -f ".mise.toml" ]]; then
+        if [[ -f "mise.toml" || -f ".mise.toml" || -f ".tool-versions" ]]; then
           echo "mise_config_exists=true" >> $GITHUB_OUTPUT
           echo "Found mise configuration file, will use it for tool versions"
         else

--- a/test/action_run_test.go
+++ b/test/action_run_test.go
@@ -55,22 +55,47 @@ func TestTerragruntCompositeAction(t *testing.T) {
 }
 
 func testActionWithMiseConfig(t *testing.T, actionConfig ActionConfig) {
-	fixturePath := prepareFixture(t, "fixture-action-execution")
-
-	// Create mise.toml in fixture
-	miseConfig := fmt.Sprintf(`[tools]
+	for _, tt := range []struct {
+		name       string
+		miseConfig string
+	}{
+		{
+			name: "mise.toml",
+			miseConfig: fmt.Sprintf(`[tools]
 terragrunt = "%s"
 opentofu = "%s"
-`, actionConfig.tgVersion, actionConfig.iacVersion)
+`, actionConfig.tgVersion, actionConfig.iacVersion),
+		},
+		{
+			name: ".mise.toml",
+			miseConfig: fmt.Sprintf(`[tools]
+terragrunt = "%s"
+opentofu = "%s"
+`, actionConfig.tgVersion, actionConfig.iacVersion),
+		},
+		{
+			name: ".tool-versions",
+			miseConfig: fmt.Sprintf(`# Tool versions
+terragrunt %s
+opentofu %s
+`, actionConfig.tgVersion, actionConfig.iacVersion),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fixturePath := prepareFixture(t, "fixture-action-execution")
 
-	miseConfigPath := filepath.Join(fixturePath, "mise.toml")
-	err := os.WriteFile(miseConfigPath, []byte(miseConfig), 0644)
-	require.NoError(t, err)
+			// Create mise config file in fixture
+			miseConfigPath := filepath.Join(fixturePath, tt.name)
+			err := os.WriteFile(miseConfigPath, []byte(tt.miseConfig), 0644)
+			require.NoError(t, err)
 
-	// Test that action works with mise.toml (no version inputs needed)
-	output := runCompositeAction(t, "", "", actionConfig.tgVersion, fixturePath, "plan")
-	assert.Contains(t, output, "Found mise configuration file")
-	assert.Contains(t, output, "Starting Terragrunt Action")
+			// Test that action works with mise config file (no version inputs needed)
+			output := runCompositeAction(t, "", "", actionConfig.tgVersion, fixturePath, "plan")
+			assert.Contains(t, output, "Found mise configuration file")
+			assert.Contains(t, output, "Starting Terragrunt Action")
+		})
+	}
 }
 
 func testActionWithInputVersions(t *testing.T, actionConfig ActionConfig) {
@@ -121,7 +146,7 @@ func runCompositeActionInternal(t *testing.T, iacVersion, iacType, tgVersion, fi
 set -e
 
 echo "=== Checking for mise.toml and validating inputs ==="
-if [[ -f "mise.toml" || -f ".mise.toml" ]]; then
+if [[ -f "mise.toml" || -f ".mise.toml" || -f ".tool-versions" ]]; then
   echo "mise_config_exists=true"
   echo "Found mise configuration file, will use it for tool versions"
 else


### PR DESCRIPTION
## Description

mise and jdx/mise-action support using .tool-versions files to specify tool dependencies. Allow using them for terragrunt-action as well.

fixes #137

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
allow using `.tool-versions` instead of `mise.toml`/`.mise.toml` to manage tool versions

### Migration Guide

N/A

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The action now recognizes `.tool-versions` as a valid mise configuration file (along with `mise.toml` and `.mise.toml`).
  * When `.tool-versions` is present, tool version installation will use it automatically instead of requiring explicit version inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->