### PR TITLE
Bump pinned mise to 2026.7.7 (fixes github-attestations lockfile install failure)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
       if: steps.mise-check.outputs.mise_config_exists == 'true'
       uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4
       with:
-        version: 2026.3.9
+        version: 2026.7.7
       env:
         MISE_GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
 
@@ -89,7 +89,7 @@ runs:
       if: steps.mise-check.outputs.mise_config_exists == 'false'
       uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4
       with:
-        version: 2026.3.9
+        version: 2026.7.7
         tool_versions: |
           terragrunt ${{ inputs.tg_version }}
           ${{ inputs.tofu_version && format('opentofu {0}', inputs.tofu_version) || '' }}


### PR DESCRIPTION
## Description

Fixes #141.

`action.yml` hard-pins the mise binary to `version: 2026.3.9` in both *Install tools with mise* steps, and exposes no input to override it. That mise version fails to install any `mise.lock` containing `provenance = "github-attestations"` entries (written by default by recent mise for `github`/`aqua`-backed tools):

```
mise ERROR Failed to install aqua:terraform-linters/tflint@0.64.0: Lockfile requires
github-attestations provenance ... but no verification was used. This may indicate a
downgrade attack. Enable the corresponding verification setting or update the lockfile.
```

mise fails closed here, so the whole action errors out before Terragrunt runs. This bumps the pin to the current release, `2026.7.7`, which installs the same lockfile successfully (it's also what `jdx/mise-action@v4` installs by default). mise's attestation/provenance path has had numerous fixes since 2026.3.9.

Both mise-action invocations are updated (the `mise.toml` path and the input-versions path).

## Release Notes (draft)

Updated the pinned mise version to `2026.7.7` so the action can install `mise.lock` files that use `github-attestations` provenance.

### Migration Guide

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pinned tool setup action to a newer version, improving compatibility and reliability when installing configured infrastructure tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->